### PR TITLE
feat: add automatic party XP award module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Kazgul-s-PF2e-XP-Award
+# Kazgul's PF2e XP Award
+
+Dieses Foundry-VTT-Modul für Pathfinder 2e (v13+) verbessert die Vergabe von Erfahrungspunkten.
+Nach dem Ende eines Encounters wird die Spielleitung automatisch gefragt, ob die berechneten XP
+direkt allen Mitgliedern der Party gutgeschrieben werden sollen. Bestätigt der SL, erhält jeder
+Charakter den vollen XP-Wert des Encounters – es findet keine Aufteilung statt – und die XP werden
+sofort auf die Charaktere verteilt.
+
+Zusätzlich enthält das Modul ein Makro **PF2e Party XP Dropdown**. Damit können XP manuell über
+einen praktischen Dialog an eine ausgewählte Party vergeben werden.
+
+## Installation
+Kopiere den Modulordner in den `Data/modules`-Pfad deiner Foundry-Installation und aktiviere
+es anschließend in der Weltverwaltung.
+

--- a/macros/party-xp-dropdown.js
+++ b/macros/party-xp-dropdown.js
@@ -1,0 +1,166 @@
+// PF2e – Party-XP per Dropdown vergeben, Ziel: Party-Actor (Foundry VTT v13+)
+// Autor: Foundry Pathfinder Coder
+
+// --- Konfiguration: feste Optionen (pro Charakter) --------------------------
+const XP_OPTIONS = [
+  { key: "trivial",  label: "Trivial – 30 XP",   value: 30  },
+  { key: "low",      label: "Low – 60 XP",       value: 60  },
+  { key: "moderate", label: "Moderate – 80 XP",  value: 80  },
+  { key: "severe",   label: "Severe – 120 XP",   value: 120 },
+  { key: "extreme",  label: "Extreme – 160 XP",   value: 160 },
+];
+
+// --- Helfer -----------------------------------------------------------------
+const applyXPPerCharacter = async (actor, deltaXP) => {
+  if (!deltaXP) return;
+
+  const currentXP = actor.system?.details?.xp?.value ?? 0;
+  const currentLevel = actor.system?.details?.level?.value ?? 1;
+
+  let newXP = currentXP + deltaXP;
+  let newLevel = currentLevel;
+
+  if (newXP >= 1000) {
+    newLevel += Math.floor(newXP / 1000);
+    newXP = newXP % 1000;
+  }
+  if (newXP < 0) newXP = 0; // Kein automatisches Downgrade
+
+  const update = {};
+  if (newLevel !== currentLevel)
+    foundry.utils.setProperty(update, "system.details.level.value", newLevel);
+  if (newXP !== currentXP)
+    foundry.utils.setProperty(update, "system.details.xp.value", newXP);
+
+  if (Object.keys(update).length) await actor.update(update);
+};
+
+/** Robust die Mitglieder einer Party ermitteln (versch. PF2e-Versionen) */
+const getPartyMembers = (party) => {
+  let members = [];
+
+  // 1) Bevorzugt: PartyPF2e#members (Set oder Array von Actoren)
+  if (party?.members) {
+    if (party.members instanceof Set) members = Array.from(party.members);
+    else if (Array.isArray(party.members)) members = party.members;
+  }
+
+  // 2) Mögliche Systemspeicherung (IDs/UUIDs)
+  if (members.length === 0 && Array.isArray(party?.system?.members)) {
+    members = party.system.members
+      .map(id => {
+        try {
+          // Unterstütze sowohl IDs als auch UUIDs
+          if (typeof id === "string" && id.includes(".")) {
+            return fromUuidSync?.(id);
+          } else {
+            return game.actors.get(id);
+          }
+        } catch { return null; }
+      })
+      .filter(a => a);
+  }
+
+  // 3) Fallback: Alle Charaktere, deren "parties" Set diese Party enthält
+  if (members.length === 0) {
+    members = game.actors.filter(a =>
+      a.type === "character" &&
+      (a.parties?.has?.(party) || a.parties?.some?.(p => p?.id === party.id))
+    );
+  }
+
+  // Nur Spieler-Charaktere
+  return members.filter(a => a?.type === "character");
+};
+
+// --- Daten vorbereiten ------------------------------------------------------
+const parties = game.actors.filter(a => a.type === "party");
+if (parties.length === 0) {
+  ui.notifications.warn("Keine Party‑Actor gefunden. Lege zuerst einen Actor vom Typ „Party“ an und füge Mitglieder hinzu.");
+  return;
+}
+const partyOptions = parties.map(p => `<option value="${p.id}">${foundry.utils.escapeHTML(p.name)}</option>`).join("");
+
+// --- Dialog UI --------------------------------------------------------------
+const selectXPOptions = XP_OPTIONS.map(o => `<option value="${o.key}">${o.label}</option>`).join("");
+
+const content = `
+<form class="flexcol" style="gap:.5rem;">
+  <div class="form-group">
+    <label>Ziel‑Party</label>
+    <select name="partyId">${partyOptions}</select>
+    <p class="notes">Die XP werden an alle Mitglieder dieser Party vergeben (pro Charakter).</p>
+  </div>
+
+  <div class="form-group">
+    <label>Voreinstellung (pro Charakter)</label>
+    <select name="preset">${selectXPOptions}</select>
+    <p class="notes">Wird ignoriert, wenn unten ein eigener XP‑Wert > 0 eingetragen ist.</p>
+  </div>
+
+  <div class="form-group">
+    <label>Eigener XP‑Wert (pro Charakter)</label>
+    <input type="number" name="custom" value="" min="-100000" step="1" placeholder="z. B. 45"/>
+    <p class="notes">Leer lassen oder 0 eintragen, um die Voreinstellung zu verwenden.</p>
+  </div>
+</form>
+`;
+
+const result = await Dialog.prompt({
+  title: "XP vergeben an Party (PF2e)",
+  content,
+  label: "XP vergeben",
+  callback: (html) => {
+    const partyId = html.find('select[name="partyId"]').val();
+    const presetKey = html.find('select[name="preset"]').val();
+    const custom = Number(html.find('input[name="custom"]').val());
+    return { partyId, presetKey, custom };
+  },
+  rejectClose: false
+});
+
+if (!result) return; // Abgebrochen
+
+const { partyId, presetKey, custom } = result;
+const party = game.actors.get(partyId);
+if (!party) return ui.notifications.error("Ausgewählte Party nicht gefunden.");
+
+const members = getPartyMembers(party);
+if (members.length === 0) return ui.notifications.warn(`Die Party "${party.name}" hat keine Mitglieder (Charaktere).`);
+
+const preset = XP_OPTIONS.find(o => o.key === presetKey) ?? XP_OPTIONS[0];
+const perCharXP = Number.isFinite(custom) && custom > 0 ? Math.trunc(custom) : preset.value;
+
+if (!Number.isFinite(perCharXP)) return ui.notifications.warn("Ungültiger XP‑Wert.");
+if (perCharXP === 0) return ui.notifications.info("0 XP vergeben – keine Änderungen.");
+
+// --- Anwenden ---------------------------------------------------------------
+const updates = [];
+for (const a of members) {
+  await applyXPPerCharacter(a, perCharXP);
+  updates.push({ name: a.name, xp: perCharXP });
+}
+
+// --- Chat-Output ------------------------------------------------------------
+const list = updates.map(u => `<li><strong>${foundry.utils.escapeHTML(u.name)}</strong>: ${u.xp > 0 ? "+" : ""}${u.xp} XP</li>`).join("");
+
+const sourceLabel = (Number.isFinite(custom) && custom > 0)
+  ? `Eigener Wert: <strong>${perCharXP} XP</strong>`
+  : `Voreinstellung: <strong>${foundry.utils.escapeHTML(preset.label)}</strong>`;
+
+const msg = `
+<div class="pf2e chat-card">
+  <header class="card-header flexrow">
+    <h3>XP-Vergabe an Party: ${foundry.utils.escapeHTML(party.name)}</h3>
+  </header>
+  <div class="card-content">
+    <p>${sourceLabel}</p>
+    <p>Mitglieder: ${members.length}</p>
+    <ul>${list}</ul>
+    <p class="notes">Level-Ups durch 1000‑XP‑Schritte werden automatisch am Charakterlevel verbucht. Klassenfeatures bitte wie gewohnt am Bogen pflegen.</p>
+  </div>
+</div>
+`;
+ChatMessage.create({ content: msg, speaker: { alias: "Spielleitung" } });
+
+ui.notifications.info(`XP vergeben: ${perCharXP} pro Charakter an Party "${party.name}" (${members.length} Mitglieder)`);

--- a/module.json
+++ b/module.json
@@ -1,0 +1,22 @@
+{
+  "name": "pf2e-xp-award",
+  "title": "PF2e XP Award",
+  "description": "QoL XP-Verteilung: Nach Encountern wird der Spielleitung angeboten, berechnete XP direkt an die Party zu vergeben. Enthält zusätzlich ein Makro zur manuellen XP-Vergabe.",
+  "version": "1.0.0",
+  "authors": [
+    { "name": "Foundry Pathfinder Coder" }
+  ],
+  "systems": ["pf2e"],
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "scripts": ["scripts/auto-party-xp.js"],
+  "macros": [
+    {
+      "name": "PF2e Party XP Dropdown",
+      "path": "macros/party-xp-dropdown.js",
+      "type": "script"
+    }
+  ]
+}

--- a/scripts/auto-party-xp.js
+++ b/scripts/auto-party-xp.js
@@ -1,0 +1,50 @@
+/**
+ * PF2e automatic XP awarding after an encounter.
+ * Prompts the GM to distribute calculated encounter XP to party actors.
+ */
+
+const applyXP = async (actor, deltaXP) => {
+  if (!deltaXP) return;
+
+  const currentXP = actor.system?.details?.xp?.value ?? 0;
+  const currentLevel = actor.system?.details?.level?.value ?? 1;
+
+  let newXP = currentXP + deltaXP;
+  let newLevel = currentLevel;
+
+  if (newXP >= 1000) {
+    newLevel += Math.floor(newXP / 1000);
+    newXP = newXP % 1000;
+  }
+  if (newXP < 0) newXP = 0;
+
+  const update = {};
+  if (newLevel !== currentLevel) foundry.utils.setProperty(update, "system.details.level.value", newLevel);
+  if (newXP !== currentXP) foundry.utils.setProperty(update, "system.details.xp.value", newXP);
+
+  if (Object.keys(update).length) await actor.update(update);
+};
+
+Hooks.on("deleteCombat", async (combat) => {
+  if (!game.ready || !game.user?.isGM) return;
+
+  const award = combat.metrics?.award;
+  const baseXP = award?.xp ?? 0;
+  const recipients = award?.recipients?.filter(a => a?.type === "character") ?? [];
+
+  if (!baseXP || recipients.length === 0) return;
+
+  const xp = baseXP * recipients.length;
+
+  const confirmed = await Dialog.confirm({
+    title: game.i18n.localize("PF2E.Encounter.AwardXP"),
+    content: `<p>${game.i18n.format("PF2E.Encounter.GrantXP", { xp, count: recipients.length })}</p>`
+  });
+  if (!confirmed) return;
+
+  for (const actor of recipients) {
+    await applyXP(actor, xp);
+  }
+
+  ui.notifications.info(game.i18n.format("PF2E.Encounter.XPAwarded", { xp, count: recipients.length }));
+});


### PR DESCRIPTION
## Summary
- prompt GMs to grant encounter XP to party members after combat
- include macro for manual party XP distribution via dropdown
- automatically award each character the full encounter XP instead of splitting
- document usage and add module manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689afbbd70d483278a06574c535bd686