### PR TITLE
Announce awarded XP in chat

### DIFF
--- a/scripts/auto-party-xp.js
+++ b/scripts/auto-party-xp.js
@@ -63,6 +63,6 @@ Hooks.on("deleteCombat", async (combat) => {
   for (const actor of recipients) {
     await applyXP(actor, xp);
   }
-
+  await ChatMessage.create({content: `The party received ${xp} XP. Well fought Ladies and Gents!`});
   ui.notifications.info(game.i18n.format("PF2E.Encounter.XPAwarded", { xp, count: recipients.length }));
 });


### PR DESCRIPTION
## Summary
- Add ChatMessage announcing XP to party members when XP is awarded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2e5c6f1083278ccdbc52daaccb4d